### PR TITLE
Registry resource refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Taking the pain out of scripting and automating xcode builds.
 
-Xcoder is a ruby wrapper around various xcode tools as well as providing project and workspace parsing and partial write support.  Xcoder also supports manipulation of keychains, packaging and uploading artefacts to testflight and provisioning profile management.
+Xcoder is a ruby wrapper around various Xcode tools as well as providing project and workspace parsing and partial write support.  Xcoder also supports manipulation of keychains, packaging and uploading artifacts to [Testflight](http://testflightapp.com) and provisioning profile management.
 
 Full documentation can be found here: http://rayh.github.com/xcoder/
 
@@ -113,9 +113,9 @@ Or enumerate installed profiles:
 		p.uninstall		# Removes the profile from ~/Library/
 	end
 
-### Testflight
+### [Testflight](http://testflightapp.com)
 
-The common output of this build/package process is to upload to testflight.  This is pretty simple with xcoder:
+The common output of this build/package process is to upload to Testflight.  This is pretty simple with Xcoder:
 
 	builder.testflight(API_TOKEN, TEAM_TOKEN) do |tf|
 	  tf.notes = "some release notes"
@@ -134,6 +134,64 @@ You can invoke your test target/bundle from the builder
 	end
 	
 This will invoke the test target, capture the output and write the junit reports to the test-reports directory.  Currently only junit is supported.
+
+## Manipulating a Project
+
+Xcoder can also create targets, configurations, and add files. Xcoder could be used to programmatically manipulate or install external sources into a project.
+
+It is important to note that Xcode gets cranky when the Xcode project file is changed by external sources. This usually causes the project and schemes to reset or maybe even cause Xcode to crash. It is often best to close the project before manipulating it with Xcoder.
+
+### Add the source and header file to the project
+
+    # Copy the physical source files into the project path `Vendor/Reachability`
+    FileUtils.cp_r "examples/Reachability/Vendor", "spec/TestProject"
+    
+    source_files = [ { 'name' => 'Reachability.m', 'path' => 'Vendor/Reachability/Reachability.m' },
+                     { 'name' => 'Reachability.h', 'path' => 'Vendor/Reachability/Reachability.h' } ]
+
+
+     # Create and traverse to the group Reachability within the Vendor folder
+     project.group('Vendor/Reachability') do
+       # Create files for each source file defined above
+       source_files.each |source| create_file source }
+     end
+     
+
+Within the project file the groups in the path are created or found and then file references are added for the two specified source files. Xcoder only updates the logical project file, it does not copy physical files, that is done by the FileUtils.
+
+
+### Adding source file to the sources build phase
+
+    source_file = project.file('Vendor/Reachability/Reachability.m')
+
+    # Select the main target of the project and add the source file to the build phase.
+
+    project.target('TestProject').sources_build_phase do
+      add_build_file source_file
+    end
+
+Adding source files does not automatically include it in any of the built targets. That is done after you add the source file to the `sources_build_phase`. First we find the source file reference, select our target and then add it as a build file.
+
+### Adding a System Framework
+
+    cfnetwork_framework = project.frameworks_group.create_system_framework 'CFNetwork'
+
+    project.target('TestProject').framework_build_phase do
+      add_build_file cfnetwork_framework
+    end 
+    
+The **CFNetwork.framework** is added to the `Frameworks` group of the project and then added to the frameworks build phase.
+
+### Saving your changes!
+
+
+    project.save!
+
+The saved file output is ugly compared to what you may normally see when you view a Xcode project file. Luckily, Xcode will fix the format of the file if you make any small changes to the project that require it to save.
+
+### More Examples
+
+Within the `specs/integration` folder there are more examples.
 
 ## Tests
 

--- a/lib/xcode/project.rb
+++ b/lib/xcode/project.rb
@@ -1,15 +1,6 @@
-require 'plist'
 require 'xcode/parsers/plutil_project_parser'
 require 'xcode/resource'
-require 'xcode/target'
-require 'xcode/configuration'
-require 'xcode/scheme'
-require 'xcode/group'
-require 'xcode/file_reference'
 require 'xcode/registry'
-require 'xcode/build_phase'
-require 'xcode/variant_group'
-require 'xcode/configuration_list'
 
 module Xcode
   

--- a/lib/xcode/registry.rb
+++ b/lib/xcode/registry.rb
@@ -1,4 +1,14 @@
+require 'xcode/build_file'
+require 'xcode/build_phase'
+require 'xcode/configuration'
+require 'xcode/configuration_list'
+require 'xcode/file_reference'
+require 'xcode/group'
+require 'xcode/resource'
+require 'xcode/scheme'
 require 'xcode/simple_identifier_generator'
+require 'xcode/target'
+require 'xcode/variant_group'
 
 module Xcode
   

--- a/lib/xcode/resource.rb
+++ b/lib/xcode/resource.rb
@@ -4,79 +4,107 @@ module Xcode
   
   #
   # Resources are not represented as a true entity within an Xcode project.
-  # When traversing through groups, targets, configurations, etc. you will find
-  # yourself interacting with these objects. As they represent a class that
-  # acts as a shim around the hash data is parsed from the project.
+  # However when traversing through groups, targets, configurations, etc. you will 
+  # find yourself interacting with these objects. As they represent a class that
+  # acts as a shim around their hash data.
   # 
-  # A resource do some things that should be explained:
+  # The goal of the {Resource} is to aid in the navigation through the project
+  # and provide a flexible system to allow for Xcoder to adapt to changes to 
+  # the Xcode project format.
   # 
-  # When a resource is created it requires an identifier and an instance of
-  # of the Registry. It finds the properties hash of that given identifier 
-  # within the registry and creates a bunch of read-only methods that allow for 
-  # easy access to those elements. This is not unlike an OpenStruct.
+  # A Resource requires an identifier and an instance of the {Registry}. Based
+  # on the supplied identifier, it peforms a look up of it's properties or hash
+  # of data. With that hash it then proceeds to create methods that allow for
+  # easy read/write access to those property elements. This is similar to Ruby's
+  # OpenStruct.
+  #
+  # @example Accessing the contents of a file reference
   # 
-  # @example of accessing the contents of a file reference
-  # 
-  #     file_resource.properties # => 
+  #     file = project.file('IOSApp/IOSAppDelegate.m').properties # => 
   # 
   #     { 'isa' => 'PBXFileReference',
   #       'lastKnownFileType' => 'sourcecode.c.h',
   #       'path' => IOSAppDelegate.h', 
   #       'sourceTree' => "<group>" }
   # 
-  #     file_resource.isa # => 'PBXFileReference'
-  #     file_resource.sourceTree # => "<group>"
+  #     file.isa # => 'PBXFileReference'
+  #     file.last_known_file_type # => 'sourcecode.c.h'
+  #     file.path # => 'IOSAppDelegate.m'
+  #     file.path = "NewIOSAppDelegate.m" # => 'NewIOSAppDeleget.m'
+  #     file.source_tree # => "<group>"
   #
+  # In the above example, you can still gain access to the internal properties
+  # through the {#properties} method. However, the {Resource} provides for you
+  # additional ruby friendly methods to access the properties.
   # 
   # To provide additional convenience when traversing through the
-  # various objects, the read-only method will check to see if the value
+  # various objects, the getter methods will check to see if the value
   # being returned matches that of a unique identifier. If it does, instead of
-  # providing that identifier as a result and then having additional code to
-  # perform the look up, it does it automatically.
+  # providing that identifier, it will instead look in the {Registry} for the 
+  # object that matches and return a new Resource automatically.
   # 
-  # @example of how this would have to been done without this indirection
+  # @example Magically accessing resources through resources
   # 
-  #     project = Xcode.project('MyProject')
-  #     main_group = project.groups
-  #     child_identifier = group.children.first
-  #     subgroup = project.registry['objects'][child_identifier]
-  #     
-  # @example of hot this works currently because of this indirection
+  #     group = project.groups
+  #     group.properties # =>
   # 
-  #     group = Xcode.project('MyProject.xcodeproj').main_group
-  #     subgroup = group.group('Models')
+  #     { "children"=>["7165D45A146B4EA100DE2F0E", 
+  #                    "7165D472146B4EA100DE2F0E", 
+  #                    "7165D453146B4EA100DE2F0E", 
+  #                    "7165D451146B4EA100DE2F0E"], 
+  #       "isa"=>"PBXGroup", 
+  #       "sourceTree"=>"<group>"}
   # 
+  #     group.children.first # => 
   # 
-  # Next, as most every one of these objects is a Hash that contain the properties
-  # instead of objects it would likely be better to encapsulate these resources
-  # within specific classes that provide additional functionality. So that when 
-  # a group resource or a file resource is returned you can perform unique 
-  # functionality with it automatically.
+  #     PBXGroup 7165D45A146B4EA100DE2F0E {"children"=>["7165D463146B4EA100DE2F0E", 
+  #                                                     "7165D464146B4EA100DE2F0E", 
+  #                                                     "7165D45B146B4EA100DE2F0E"], 
+  #                                        "isa"=>"PBXGroup", 
+  #                                        "path"=>"TestProject", 
+  #                                        "sourceTree"=>"<group>"} 
   # 
-  # This is done by using the 'isa' property field which contains the type of
-  # content object. Instead of creating an object and encapsulating if a module
-  # that matches the name of the 'isa', that module of functionality is 
-  # automatically mixed-in to provide that functionality.
+  # In this example when accessing the first element of children instead of an
+  # identifier string being returned the child resource is returned. This
+  # functionality is in place to allow Xcoder to flexibly conform to new relationships 
+  # that may exist or come to exist.
+  # 
+  # Lastly, a {Resource} is simply not enough to describe most of the objects
+  # within an Xcode project as each object has unique functionality that needs 
+  # to be able to perform. So each resource when it is created will query the
+  # {Registry#isa_to_module} hash to determine the functionality that it needs
+  # to additionally extend into the Resource.
+  # 
+  # This `isa` property mapped to Ruby modules allows for the easy expansion of
+  # new objects or for changes to be made to existing ones as needed.
   # 
   class Resource
     
-    # The unique identifier for this resource
+    # @return [String] the unique identifier for this resource
     attr_accessor :identifier
     
-    # The properties hash that is known about the resource
+    # The raw properties hash that is known about the resource. This is the best
+    # way to manipulate the raw values of the resource.
+    # 
+    # @return [Hash] the raw properties hash for the object
     attr_accessor :properties
     
     # The registry of all objects within the project file which all resources
     # have a reference to so that they can retrieve any items they may own that
-    # are simply referenced by identifiers.
-    attr_accessor :registry
+    # are simply referenced by identifiers. This registry is used to convert
+    # identifier keys to resource objects. It is also passed to any resources
+    # that are created.
+    # 
+    # @return [Registry] the registry for the entire project.
+    attr_reader :registry
     
     #
     # Definiing a property allows the creation of an alias to the actual value.
     # This level of indirection allows for the replacement of values which are
     # identifiers with a resource representation of it.
     # 
-    # @note This is used internally by the resource when it is created.
+    # @note This is used internally by the resource when it is created to create
+    #   the getter/setter methods.
     # 
     # @param [String] name of the property
     # @param [String] value of the property
@@ -128,6 +156,8 @@ module Xcode
 
       end
       
+      # Generate a setter method for this property based on the given name.
+      
       self.class.send :define_method, "#{name.underscore}=" do |new_value|
         @properties[name] = new_value
       end
@@ -136,22 +166,25 @@ module Xcode
     end
 
     #
-    # Within the code, a single resource is created and that is with the root
-    # projet object. All other resources are created through the indirecation of
-    # the above property methods.
+    # A Resource is created during {Project#initialize}, when the project is
+    # first parsed. Afterwards each Resource is usually generated through the 
+    # special getter method defined through {#define_property}.
+    # 
+    # @see Project#initialize
+    # @see #defined_property
     # 
     # @param [String] identifier the unique identifier for this resource.
-    # @param [Types] details Description
+    # @param [Registry] registry the core registry for the system. 
     #
-    def initialize identifier, details
-      @registry = details
+    def initialize identifier, registry
+      @registry = registry
       @properties = {}
       @identifier = identifier
       
       # Create property methods for all of the key-value pairs found in the
       # registry for specified identifier.
       
-      Array(details.properties(@identifier)).each do |key,value| 
+      Array(registry.properties(@identifier)).each do |key,value| 
         send :define_property, key, value
       end
       
@@ -173,7 +206,7 @@ module Xcode
     # 
     # @example group adding a files and then saving itself
     # 
-    #     group = project.main_group
+    #     group = project.groups
     #     group.create_file 'name' => 'AppDelegate.m', 'path' => 'AppDelegate.m'
     #     group.save!
     # 
@@ -201,7 +234,6 @@ module Xcode
     def to_xcplist
       %{
         #{@identifier} = { #{ @properties.map {|k,v| "#{k} = \"#{v.to_xcplist}\"" }.join("; ") } }
-        
       }
     end
     

--- a/lib/xcode/resource.rb
+++ b/lib/xcode/resource.rb
@@ -1,4 +1,5 @@
 require 'xcode/core_ext/string'
+require 'xcode/registry'
 
 module Xcode
   

--- a/lib/xcode/simple_identifier_generator.rb
+++ b/lib/xcode/simple_identifier_generator.rb
@@ -1,17 +1,64 @@
 module SimpleIdentifierGenerator
   extend self
   
+  MAX_IDENTIFIER_GENERATION_ATTEMPTS = 10
+  
   #
   # Generate an identifier string
+  # 
+  # @example generating a new identifier
+  # 
+  #     SimpleIdentifierGenerator.generate # => "E21EB9EE14E359840058122A"
+  # 
+  # @example generating a new idenitier ensuring it does not match existing keys
+  # 
+  #     SimpleIdentifierGenerator.generate :existing_keys => [ "E21EB9EE14E359840058122A" ] # => "2574D65B0D2FFDB5D0372B4A"
+  # 
+  # @param [Hash] options contains any additional parameters; namely the 
+  #   `:existing_keys` parameters which will help ensure uniqueness.
+  # 
+  # @return [String] a 24-length string that contains only hexadecimal characters.
+  # 
+  def generate(options = {})
+    
+    existing_keys = options[:existing_keys] || []
+    
+    # Ensure that the identifier generated is unique
+    identifier_generation_count = 0
+    
+    new_identifier = generate_new_key
+    
+    while existing_keys.include?(new_identifier)
+      
+      new_identifier = generate_new_key
+      
+      # Increment our identifier generation count and if we reach our max raise
+      # an exception as something has gone horribly wrong.
+
+      identifier_generation_count += 1
+      if identifier_generation_count > MAX_IDENTIFIER_GENERATION_ATTEMPTS
+        raise "SimpleIdentifierGenerator is unable to generate a unique identifier"
+      end
+    end
+    
+    new_identifier
+    
+  end
+  
+  private
+  
+  #
+  # Generates a new identifier string
   # 
   # @example identifier string
   # 
   #     "E21EB9EE14E359840058122A"
   # 
-  # @return [String] a 24-length string that contains only hexadecimal characters.
+  # @return [String] a new identifier string
   # 
-  def generate
+  def generate_new_key
     range = ('A'..'F').to_a + (0..9).to_a
     24.times.inject("") {|ident| "#{ident}#{range.sample}" }
   end
+  
 end

--- a/lib/xcode/target.rb
+++ b/lib/xcode/target.rb
@@ -1,4 +1,4 @@
-require_relative 'build_file'
+require 'xcode/build_file'
 
 module Xcode
   


### PR DESCRIPTION
- Doc changes to ensure the examples and explanations are accurate
- Cleaned up the requires and moved them out of the project files as they belong in the Resource/Registry area.
- Identifier generation retry logic moved to the actual source that is generating the identifier
- Removed a require_relative to ensure better compatible with 1.8.7 (though I have not checked it and I know the tests are not compat).
