### PR TITLE
Vendor compatibility 

### DIFF
--- a/lib/xcode/configuration.rb
+++ b/lib/xcode/configuration.rb
@@ -316,9 +316,21 @@ module Xcode
       if Configuration.setting_name_to_property(name)
         send("append_to_#{Configuration.setting_name_to_property(name)}",value)
       else
-        # @todo this will likely raise some errors if trying to append a string
+
+        # @note this will likely raise some errors if trying to append a string
         #   to an array, but that likely means a new property should be defined.
-        build_settings[name] = build_settings[name] + value
+  
+        if build_settings[name].is_a?(Array)
+          # Ensure that we are appending an array to the array; Array() does not
+          # work in this case in the event we were to pass in a Hash.
+          value = value.is_a?(Array) ? value : [ value ]
+          build_settings[name] = build_settings[name] + value
+        else
+          # Ensure we handle the cases where a nil value is present that we append
+          # correctly to the value.
+          build_settings[name] = build_settings[name].to_s + value.to_s
+        end
+       
       end
     end
     

--- a/lib/xcode/configurations/boolean_property.rb
+++ b/lib/xcode/configurations/boolean_property.rb
@@ -36,8 +36,16 @@ module Xcode
         value.to_s =~ /^(?:NO|false)$/ ? "NO" : "YES"
       end
       
+      #
+      # @note Appending boolean properties has no real good default operation. What
+      #   happens in this case is that whatever you decide to append will automatically
+      #   override the previously existing settings.
+      # 
+      # @param [Types] original the original value to be appended
+      # @param [Types] value Description
+      #
       def append(original,value)
-        save(original) | save(value)
+        save(value)
       end
   
     end

--- a/lib/xcode/file_reference.rb
+++ b/lib/xcode/file_reference.rb
@@ -67,8 +67,7 @@ module Xcode
     # @return [Hash] system framework properties
     # 
     def self.system_framework(name,properties = {})
-
-      name = name[/(.+)(?:\.framework)?$/,1]
+      name = name.gsub(File.extname(name),"")
       
       default_properties = { 'isa' => 'PBXFileReference',
         'lastKnownFileType' => 'wrapper.framework', 


### PR DESCRIPTION
Fixed a few more issues
- Boolean properties were not being appended properly, because the comparison was not being done right. I also opted to simply take the last value that the user has proposed as merging booleans could go wrong if I put some AND/OR logic on them.
- Frameworks were being added with double the framework "CoreData.framework.framework".
- Unknown properties were not being appended correctly if they were nil, so I updated it to ensure it tries to append arrays (if they are arrays) and simply `#to_s` all else.
