### PR TITLE
Allow for unique identifiers to be 24-length and larger

### DIFF
--- a/lib/xcode/registry.rb
+++ b/lib/xcode/registry.rb
@@ -46,7 +46,7 @@ module Xcode
     #   identifier; false if it is not.
     # 
     def self.is_identifier? value
-      value =~ /^[0-9A-F]{24}$/
+      value =~ /^[0-9A-F]{24,}$/
     end
 
     #


### PR DESCRIPTION
@keithpitt shared with me an example of some unique identifiers that were much larger then the expected 24 length. Xcode doesn't care what you use and I think that it would be alright to open up xcoder to believe that anything that is a [24 length hexadecimal string or greater](http://www.monobjc.net/index.php?page=xcode-project-file-format) to be a valid identifier.
