### PR TITLE
Vendor more append fixes

### DIFF
--- a/lib/xcode/configuration.rb
+++ b/lib/xcode/configuration.rb
@@ -324,18 +324,28 @@ module Xcode
         send("append_to_#{Configuration.setting_name_to_property(name)}",value)
       else
 
-        # @note this will likely raise some errors if trying to append a string
-        #   to an array, but that likely means a new property should be defined.
+        # @note this will likely raise some errors if trying to append a booleans
+        #   to fixnums, strings to booleans, symbols + arrays, etc. but that likely 
+        #   means a new property should be defined so that the appending logic
+        #   wil behave correctly.
   
         if build_settings[name].is_a?(Array)
+          
           # Ensure that we are appending an array to the array; Array() does not
           # work in this case in the event we were to pass in a Hash.
           value = value.is_a?(Array) ? value : [ value ]
-          build_settings[name] = build_settings[name] + value
+          build_settings[name] = build_settings[name] + value.compact
+          
         else
+          
           # Ensure we handle the cases where a nil value is present that we append
-          # correctly to the value.
-          build_settings[name] = build_settings[name].to_s + value.to_s
+          # correctly to the value. We also need to try and leave intact boolean
+          # values which may be stored
+          
+          value = "" unless value
+          build_settings[name] = "" unless build_settings[name]
+          
+          build_settings[name] = build_settings[name] + value
         end
        
       end

--- a/lib/xcode/configuration.rb
+++ b/lib/xcode/configuration.rb
@@ -285,7 +285,9 @@ module Xcode
     # @return [String,Array,Hash] the value stored for the specified configuration
     #  
     def get(name)
-      if Configuration.setting_name_to_property(name)
+      if respond_to?(name)
+        send(name)
+      elsif Configuration.setting_name_to_property(name)
         send Configuration.setting_name_to_property(name)
       else
         build_settings[name]
@@ -299,7 +301,9 @@ module Xcode
     # @param [String,Array,Hash] value the value to store for the specific setting
     #
     def set(name, value)
-      if Configuration.setting_name_to_property(name)
+      if respond_to?(name)
+        send("#{name}=",value)
+      elsif Configuration.setting_name_to_property(name)
         send("#{Configuration.setting_name_to_property(name)}=",value)
       else
         build_settings[name] = value
@@ -313,7 +317,11 @@ module Xcode
     # @param [String,Array,Hash] value the value to store for the specific setting
     #
     def append(name, value)
-      if Configuration.setting_name_to_property(name)
+      require 'ruby-debug'
+      debugger
+      if respond_to?(name)
+        send("append_to_#{name}",value)
+      elsif Configuration.setting_name_to_property(name)
         send("append_to_#{Configuration.setting_name_to_property(name)}",value)
       else
 

--- a/lib/xcode/configuration.rb
+++ b/lib/xcode/configuration.rb
@@ -317,8 +317,7 @@ module Xcode
     # @param [String,Array,Hash] value the value to store for the specific setting
     #
     def append(name, value)
-      require 'ruby-debug'
-      debugger
+      
       if respond_to?(name)
         send("append_to_#{name}",value)
       elsif Configuration.setting_name_to_property(name)

--- a/lib/xcode/configurations/array_property.rb
+++ b/lib/xcode/configurations/array_property.rb
@@ -28,7 +28,7 @@ module Xcode
       end
       
       def append(original,value)
-        (Array(original) + Array(value)).uniq
+        (open(original) + Array(value)).uniq
       end
   
     end

--- a/lib/xcode/configurations/key_value_array_property.rb
+++ b/lib/xcode/configurations/key_value_array_property.rb
@@ -32,7 +32,7 @@ module Xcode
       # back out to a key=value pair array.
       # 
       def append(original,value)
-        all_values = (Array(original) + Array(value)).map {|key_value| key_value.split("=") }.flatten
+        all_values = (open(original) + Array(value)).map {|key_value| key_value.split("=") }.flatten
         Hash[*all_values].map {|k,v| "#{k}=#{v}" }
       end
   

--- a/lib/xcode/configurations/space_delimited_string_property.rb
+++ b/lib/xcode/configurations/space_delimited_string_property.rb
@@ -26,11 +26,16 @@ module Xcode
       extend self
   
       #
+      # While the space delimited string can and is often stored in that way,
+      # it appears as though Xcode is now possibly storing these values in a format
+      # that the parser is returning as an Array. So if the raw value is an
+      # array, simply return that raw value instead of attempting to convert it.
+      # 
       # @param [Nil,String] value stored within the build settings
       # @return [Array<String>] a list of the strings that are within this string
       # 
       def open(value)
-        value.to_s.split(" ")
+        value.is_a?(Array) ? value : value.to_s.split(" ")
       end
   
       #

--- a/lib/xcode/configurations/space_delimited_string_property.rb
+++ b/lib/xcode/configurations/space_delimited_string_property.rb
@@ -41,8 +41,17 @@ module Xcode
         Array(value).join(" ")
       end
       
+      #
+      # Space Delimited Strings are not unlike arrays and those we assume that the
+      # inputs are going to be two arrays that will be joined and then ensured 
+      # that only the unique values are saved.
+      # 
+      # @param [Nil,String] original the original value stored within the field
+      # @param [Nil,String,Array] value the new values that will coerced into an array
+      #   and joined with the original values.
+      #
       def append(original,value)
-        save( ( open(original) + open(value) ).uniq )
+        save( ( open(original) + Array(value)).uniq )
       end
   
     end

--- a/lib/xcode/configurations/string_property.rb
+++ b/lib/xcode/configurations/string_property.rb
@@ -20,7 +20,7 @@ module Xcode
       end
       
       def append(original,value)
-        original.to_s + value.to_s
+        open(original) + value.to_s
       end
   
     end

--- a/lib/xcode/group.rb
+++ b/lib/xcode/group.rb
@@ -98,7 +98,9 @@ module Xcode
     #   if no matches were found.
     # 
     def exists?(name)
-      children.find_all {|child| child.name == name }
+      children.find_all do |child| 
+        child.name ? (child.name == name) : (File.basename(child.path) == name)
+      end
     end
     
     #
@@ -144,11 +146,13 @@ module Xcode
       # found.
       
       find_file_by = file_properties['name'] || file_properties['path']
+      
       found_or_created_file = exists?(find_file_by).first
       
       unless found_or_created_file
         found_or_created_file = create_child_object FileReference.file(file_properties)
       end
+      
       found_or_created_file.supergroup = self
       
       found_or_created_file

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -68,10 +68,17 @@ describe Xcode::Configuration do
 
     it "should append to  existing settings" do
       subject.set 'OTHER_LDFLAGS', '-NONE'
-      subject.append 'OTHER_LDFLAGS', '-FOR -ME'
+      subject.append 'OTHER_LDFLAGS', '-FOR'
+      subject.append 'OTHER_LDFLAGS', [ '-FOR' , '-ME' ]
       settings['OTHER_LDFLAGS'].should == "-NONE -FOR -ME"
     end
     
+     it "should append to  existing settings" do
+      subject.set 'OTHER_LDFLAGS', '-NONE -FOR'
+      subject.append 'OTHER_LDFLAGS', '-FOR'
+      subject.append 'OTHER_LDFLAGS', [ '-FOR' , '-ME' ]
+      settings['OTHER_LDFLAGS'].should == "-FOR -ME"
+    end
   end
   
   describe "#get" do


### PR DESCRIPTION
I thought I was making some mistakes with the append specifically with the Space Delimited Type. To ensure that I was consistent across the board I made sure that all the append calls will open the original value correctly before appending it to the new value.

Also, it seems that with Xcode 4.3.2, or perhaps it has been present all along, but it seems that a space delimited array will save now as an normal array. Which means the space delimited array needs to support if it happens to be an array.
