### PR TITLE
Xcode::PLUTILProjectParser saves and reformats the project file

### DIFF
--- a/lib/xcode/parsers/plutil_project_parser.rb
+++ b/lib/xcode/parsers/plutil_project_parser.rb
@@ -14,6 +14,24 @@ module Xcode
       xml = `plutil -convert xml1 -o - "#{path}"`
       Plist::parse_xml(xml)
     end
+
+    #
+    # Save the outputed string data to the specified project file path and then
+    # formats that data to be prettier than the default output.
+    # 
+    def save path,data
+     
+      File.open(path,'w') do |file|
+        file.puts data
+      end
+
+      #
+      
+      if File.exists?(path)
+        `pl -input #{path} -output #{path}`
+      end
+
+   end
   
   end
   

--- a/lib/xcode/project.rb
+++ b/lib/xcode/project.rb
@@ -195,16 +195,15 @@ module Xcode
     # @param [String] path the path to save the project
     #
     def save(path)
-      Dir.mkdir(path) unless File.exists?(path)
       
+      Dir.mkdir(path) unless File.exists?(path)
       project_filepath = "#{path}/project.pbxproj"
       
       # @toodo Save the workspace when the project is saved
       # FileUtils.cp_r "#{path}/project.xcworkspace", "#{path}/project.xcworkspace"
+  
+      Xcode::PLUTILProjectParser.save "#{@path}/project.pbxproj", to_xcplist
       
-      File.open(project_filepath,'w') do |file|
-        file.puts to_xcplist
-      end
     end
     
     #


### PR DESCRIPTION
Found this snazzy command to reformat the output to make it nicer then the default output. Minor cosmetic issue.
