### PR TITLE
Scheme name should be quoted to accommodate names containing spaces

### DIFF
--- a/lib/xcode/builder.rb
+++ b/lib/xcode/builder.rb
@@ -78,7 +78,7 @@ module Xcode
       cmd << "-project \"#{@target.project.path}\""
       cmd << "-sdk #{@sdk}" unless @sdk.nil?
       
-      cmd << "-scheme #{@scheme.name}" unless @scheme.nil?
+      cmd << "-scheme \"#{@scheme.name}\"" unless @scheme.nil?
       cmd << "-target \"#{@target.name}\"" if @scheme.nil?
       cmd << "-configuration \"#{@config.name}\"" if @scheme.nil?
       
@@ -191,7 +191,7 @@ module Xcode
       cmd << "-sdk #{sdk}" unless sdk.nil?
       cmd << "-project \"#{@target.project.path}\""
       
-      cmd << "-scheme #{@scheme.name}" unless @scheme.nil?
+      cmd << "-scheme \"#{@scheme.name}\"" unless @scheme.nil?
       cmd << "-target \"#{@target.name}\"" if @scheme.nil?
       cmd << "-configuration \"#{@config.name}\"" if @scheme.nil?
       


### PR DESCRIPTION
Quotes the Scheme name when generating build commands. fixes rayh/xcoder#27
