### PR TITLE
Prevent crash app when a test fail

### DIFF
--- a/lib/xcode/builder.rb
+++ b/lib/xcode/builder.rb
@@ -53,9 +53,8 @@ module Xcode
         # Let the failure bubble up unless parser has got an error from the output
         raise e unless parser.failed?
       end
-      exit 1 if parser.failed?
-      
-      self
+      parser
+
     end
     
     def testflight(api_token, team_token)

--- a/lib/xcode/test/ocunit_report_parser.rb
+++ b/lib/xcode/test/ocunit_report_parser.rb
@@ -31,7 +31,11 @@ module Xcode
       def unexpected?
         @unexpected
       end
-      
+
+      def succeed?
+        !self.failed?
+      end
+
       def failed?
         @failed or @unexpected
       end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -94,6 +94,14 @@ describe Xcode::Builder do
         subject.test :sdk => 'macosx10.7'
       end
       
+      it "should not exit when test failed" do
+        Xcode::Shell.stub(:execute)
+        fake_parser = stub(:parser)
+        fake_parser.stub(:failed? => true)
+        Xcode::Test::OCUnitReportParser.stub(:new => fake_parser)
+        subject.test
+      end
+      
     end
 
     describe "#clean" do
@@ -110,7 +118,7 @@ describe Xcode::Builder do
       end
 
 
-      it "should clean the project with the default parametesr" do
+      it "should clean the project with the default parameter" do
         Xcode::Shell.should_receive(:execute).with(default_clean_parameters)
         subject.clean
       end

--- a/spec/test_report_spec.rb
+++ b/spec/test_report_spec.rb
@@ -77,12 +77,14 @@ describe Xcode::Test::OCUnitReportParser do
   
   it "should detect a passing report" do
     t = example_report
-    t.failed?.should==false
+    t.should be_succeed
+    t.should_not be_failed
   end
   
   it "should detect a failing report" do 
     t = example_failing_report
-    t.failed?.should==true
+    t.should_not be_succeed
+    t.should be_failed
   end
   
   it "should record a failure" do


### PR DESCRIPTION
Re: #39, return report parser object in builder#test, so that we can review test result later.

Also add OCUnitReportParser#succeed? method that mirror #failed?
