### PR TITLE
Fix project.save(path) to save to the path, not @path

### DIFF
--- a/lib/xcode/project.rb
+++ b/lib/xcode/project.rb
@@ -222,7 +222,7 @@ module Xcode
       # @toodo Save the workspace when the project is saved
       # FileUtils.cp_r "#{path}/project.xcworkspace", "#{path}/project.xcworkspace"
   
-      Xcode::PLUTILProjectParser.save "#{@path}/project.pbxproj", to_xcplist
+      Xcode::PLUTILProjectParser.save "#{path}/project.pbxproj", to_xcplist
       
     end
     


### PR DESCRIPTION
Otherwise there's no way to save the project to an alternate path (without using the project parser manually)
