### PR TITLE
Allow a user to pass custom environment variables to the build call

### DIFF
--- a/lib/xcode/builder.rb
+++ b/lib/xcode/builder.rb
@@ -215,7 +215,7 @@ module Xcode
     end
     
     def build_command(options = {})
-      options = {:sdk => @sdk}.merge options
+      options = {:sdk => @sdk, :env => {}}.merge options
       profile = install_profile
       cmd = []
       cmd << "xcodebuild"
@@ -231,6 +231,11 @@ module Xcode
       cmd << "OBJROOT=\"#{@objroot}\""
       cmd << "SYMROOT=\"#{@symroot}\""
       cmd << "PROVISIONING_PROFILE=#{profile.uuid}" unless profile.nil?
+
+      options[:env].each_pair do |key, value|
+        cmd << "#{key}=\"#{value}\""
+      end
+
       cmd
     end
     

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -31,6 +31,13 @@ describe Xcode::Builder do
         Xcode::Shell.should_receive(:execute).with(expected)
         subject.build :sdk => 'macosx10.7'
       end
+
+      it "should allow custom environment variables to be passed along" do
+        expected = default_build_parameters
+        expected << "SOME_OTHER_VAR=\"abc123\""
+        Xcode::Shell.should_receive(:execute).with(expected)
+        subject.build :env => { 'SOME_OTHER_VAR' => 'abc123' }
+      end
       
     end
     


### PR DESCRIPTION
In one of my projects, I ran into a need to pass custom environment variables to a build operation and patched xcoder to handle that. Figured I'd push the change back upstream as well. A spec is included.
