### PR TITLE
Prefer file paths over file names when looking up existing buildfiles

### DIFF
--- a/lib/xcode/build_phase.rb
+++ b/lib/xcode/build_phase.rb
@@ -132,7 +132,7 @@ module Xcode
     #   to this individual file.
     #
     def add_build_file(file,settings = {})
-      find_file_by = file.name || file.path
+      find_file_by = file.path || file.name
       unless build_file(find_file_by)
         new_build_file = @registry.add_object BuildFile.buildfile(file.identifier,settings)
         @properties['files'] << new_build_file.identifier


### PR DESCRIPTION
Otherwise there's no way to add two build files with the same name, but different paths, to the same build phase.
