### PR TITLE
Add support for coloring the test output

### DIFF
--- a/lib/xcode/builder/base_builder.rb
+++ b/lib/xcode/builder/base_builder.rb
@@ -59,7 +59,7 @@ module Xcode
         if block_given?
           yield(report)
         else
-          report.add_formatter :stdout
+          report.add_formatter :stdout, { :color_output => true }
           report.add_formatter :junit, 'test-reports'
         end
 

--- a/lib/xcode/test/formatters/stdout_formatter.rb
+++ b/lib/xcode/test/formatters/stdout_formatter.rb
@@ -8,7 +8,7 @@ module Xcode
         
         def initialize(options = {})
           @errors = []
-          @color_output = false
+          @color_output = terminal_supports_colors?
           options.each { |k,v| self.send("#{k}=", v) }
         end
         
@@ -75,6 +75,19 @@ module Xcode
         def print(text, color = :default)
           color_params = color_output? ? color : {}
           super(text.colorize(color_params))
+        end
+        
+        def terminal_supports_colors?
+          # No colors unless we are being run via a TTY
+          return false unless $stdout.isatty
+          
+          # Check if the terminal supports colors
+          colors = `tput colors 2> /dev/null`.chomp
+          if $?.exitstatus != 0
+            colors.to_i >= 8
+          else
+            false
+          end
         end
                 
       end # StdoutFormatter

--- a/xcoder.gemspec
+++ b/xcoder.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "nokogiri"
   s.add_runtime_dependency "builder"
   s.add_runtime_dependency "rest-client"
+  s.add_runtime_dependency "colorize"
 end


### PR DESCRIPTION
I have added support for colorizing the output emitted by the `Xcode:Test:Formatters:StdoutFormatter` class. It basically just emits a red/green dot and summary text to given you a quick indication of pass/failure.

I added a dependency on the Colorize gem, but this could easily be dropped in favor of internal control codes if its a big deal.

It's defaulted to enabled at the moment, but I partially wired support for configuration -- we may want to design a pattern for passing options in from the `test` method into the formatters (i.e. `:stdout_formatter_options => { :colorize_output => true }`) or I could add a class level configuration for it.

Let me know if there's interest in merging the support and what you are thinking in terms of changes.
