### PR TITLE
Json and formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 gem 'rake'
 
 gem 'builder'
-gem 'json'
+gem 'multi_json'
 gem 'plist'
 gem 'rest-client'
 gem 'yard'

--- a/lib/xcode/builder/scheme_builder.rb
+++ b/lib/xcode/builder/scheme_builder.rb
@@ -1,32 +1,34 @@
-module Xcode  
-  
+module Xcode
+
   class Workspace
     def to_xcodebuild_option
       "-workspace \"#{self.path}\""
     end
   end
-  
+
   class Project
     def to_xcodebuild_option
       "-project \"#{self.path}\""
     end
   end
-  
+
   module Builder
     class SchemeBuilder < BaseBuilder
-  
+
       def initialize(scheme)
-        @scheme     = scheme        
-        super @scheme.build_targets.last, @scheme.build_config
+        @scheme     = scheme
+        @target     = @scheme.build_targets.last
+        super @target, @target.config(@scheme.build_config)
       end
-        
+
       def xcodebuild
         cmd = super
-        cmd << @scheme.parent.to_xcodebuild_option        
+        cmd << @scheme.parent.to_xcodebuild_option
         cmd << "-scheme \"#{@scheme.name}\""
+        cmd << "-configuration \"#{@scheme.build_config}\""
         cmd
       end
-      
+
     end
   end
 end

--- a/lib/xcode/configuration_list.rb
+++ b/lib/xcode/configuration_list.rb
@@ -1,9 +1,9 @@
 module Xcode
   module ConfigurationList
-    
-    # 
+
+    #
     # @example configuration list
-    # 
+    #
     #     7165D47D146B4EA100DE2F0E /* Build configuration list for PBXNativeTarget "TestProject" */ = {
     #       isa = XCConfigurationList;
     #       buildConfigurations = (
@@ -13,73 +13,73 @@ module Xcode
     #       defaultConfigurationIsVisible = 0;
     #       defaultConfigurationName = Release;
     #     };
-    def self.configration_list
+    def self.configuration_list
       { 'isa' => 'XCConfigurationList',
         'buildConfigurations' => [],
         'defaultConfigurationIsVisible' => '0',
         'defaultConfigurationName' => '' }
     end
-    
+
     #
     # @return [Hash] a hash of symbol names to configuration names.
-    # 
+    #
     def self.symbol_config_name_to_config_name
       { :debug => 'Debug', :release => 'Release' }
     end
-    
+
     #
     # Create a configuration for this ConfigurationList. This configuration needs
     # to have a name.
-    # 
+    #
     # @note unique names are currently not enforced but likely necessary for the
     #   the target to be build successfully.
-    # 
+    #
     # @param [Types] name Description
     #
     def create_config(name)
-      
+
       name = ConfigurationList.symbol_config_name_to_config_name[name] if ConfigurationList.symbol_config_name_to_config_name[name]
-      
-      # @todo a configuration has additional fields that are ususally set with 
+
+      # @todo a configuration has additional fields that are ususally set with
       #   some target information for the title.
-      
+
       new_config = @registry.add_object(Configuration.default_properties(name))
       @properties['buildConfigurations'] << new_config.identifier
-      
+
       yield new_config if block_given?
-      
+
       new_config.save!
     end
-    
+
     #
     # @return [BuildConfiguration] the build configuration that is set to default;
     #   nil if no configuration has been set as default.
-    # 
+    #
     def default_config
       build_configurations.find {|config| config.name == default_configuration_name }
     end
-    
+
     #
     # @return [String] the name of the default build configuration; nil if no
     #   configuration has been set as default.
-    # 
+    #
     def default_config_name
       default_configuration_name
     end
-    
+
     #
     # @todo allow the ability for a configuration to set itself as default and/or
     #   let a configuration be specified as a parameter here. Though we need
     #   to check to see that the configuration is part of the this configuration
     #   list.
-    # 
-    # @param [String] name of the build configuration to set as the default 
+    #
+    # @param [String] name of the build configuration to set as the default
     #   configuration; specify nil if you want to remove any default configuration.
     #
     def set_default_config(name)
       # @todo ensure that the name specified is one of the available configurations
       @properties['defaultConfigurationName'] = name
     end
-    
+
   end
 end

--- a/lib/xcode/deploy/testflight.rb
+++ b/lib/xcode/deploy/testflight.rb
@@ -1,11 +1,10 @@
 require 'rest-client'
-require 'json'
 
 module Xcode
   module Deploy
     class Testflight
       attr_accessor :api_token, :team_token, :notify, :proxy, :notes, :lists
-    
+
       def initialize(api_token, team_token)
         @api_token = api_token
         @team_token = team_token
@@ -14,13 +13,13 @@ module Xcode
         @lists = []
         @proxy = ENV['http_proxy'] || ENV['HTTP_PROXY']
       end
-    
+
       def upload(ipa_path, dsymzip_path=nil)
         puts "Uploading to Testflight..."
-      
+
         # RestClient.proxy = @proxy || ENV['http_proxy'] || ENV['HTTP_PROXY']
         # RestClient.log = '/tmp/restclient.log'
-        # 
+        #
         # response = RestClient.post('http://testflightapp.com/api/builds.json',
         #   :file => File.new(ipa_path),
         #   :dsym => File.new(dsymzip_path),
@@ -30,13 +29,13 @@ module Xcode
         #   :notify => @notify ? 'True' : 'False',
         #   :distribution_lists => @lists.join(',')
         # )
-        # 
+        #
         # json = JSON.parse(response)
         # puts " + Done, got: #{json.inspect}"
         # json
-      
+
         cmd = Xcode::Shell::Command.new 'curl'
-        cmd << "--proxy #{@proxy}" unless @proxy.nil? or @proxy=='' 
+        cmd << "--proxy #{@proxy}" unless @proxy.nil? or @proxy==''
         cmd << "-X POST http://testflightapp.com/api/builds.json"
         cmd << "-F file=@\"#{ipa_path}\""
         cmd << "-F dsym=@\"#{dsymzip_path}\"" unless dsymzip_path.nil?
@@ -45,14 +44,14 @@ module Xcode
         cmd << "-F notes=\"#{@notes}\"" unless @notes.nil?
         cmd << "-F notify=#{@notify ? 'True' : 'False'}"
         cmd << "-F distribution_lists='#{@lists.join(',')}'" unless @lists.count==0
-      
+
         response = Xcode::Shell.execute(cmd)
-      
-        json = JSON.parse(response.join(''))
+
+        json = MultiJson.load(response.join(''))
         puts " + Done, got: #{json.inspect}"
-      
+
         yield(json) if block_given?
-      
+
         json
       end
     end

--- a/lib/xcode/scheme.rb
+++ b/lib/xcode/scheme.rb
@@ -5,7 +5,8 @@ module Xcode
   # Schemes are an XML file that describe build, test, launch and profile actions
   # For the purposes of Xcoder, we want to be able to build and test
   class Scheme
-    attr_reader :parent, :path, :name, :build_config, :build_targets
+    attr_reader :parent, :path, :name, :build_targets
+    attr_accessor :build_config
 
     #
     # Parse all the schemes given the current project.
@@ -19,21 +20,21 @@ module Xcode
     #
     def self.find_in_workspace(workspace)
       schemes = find_in_path(workspace, workspace.path)
-      
+
       # Project level schemes
       workspace.projects.each do |project|
         schemes+=project.schemes
       end
-      
+
       schemes
     end
-    
+
     # Parse all the scheme files that can be found at the given path. Schemes
     # can be defined as `shared` schemes and then `user` specific schemes. Parsing
     # the schemes will load the shared ones and then the current acting user's
     # schemes.
     #
-    # 
+    #
     # @param project or workspace in which the scheme is contained
     # @return [Array<Scheme>] the shared schemes and user specific schemes found
     #   within the project/workspace at the path defined for schemes.
@@ -43,17 +44,17 @@ module Xcode
         Xcode::Scheme.new(parent: parent, root: path, path: scheme_path)
       end
     end
-    
+
     def initialize(params={})
       @parent = params[:parent]
       @path = File.expand_path params[:path]
       @root = File.expand_path(File.join(params[:root],'..'))
       @name = File.basename(path).gsub(/\.xcscheme$/,'')
-      doc = Nokogiri::XML(open(@path))      
-      
+      doc = Nokogiri::XML(open(@path))
+
       parse_build_actions(doc)
     end
-    
+
     # Returns a builder for building this scheme
     def builder
       Xcode::Builder::SchemeBuilder.new(self)
@@ -84,23 +85,23 @@ module Xcode
     def self.current_user_schemes_paths(root)
       Dir["#{root}/xcuserdata/#{ENV['USER']}.xcuserdatad/xcschemes/*.xcscheme"]
     end
-    
+
     def target_from_build_reference(buildableReference)
       project_name  = buildableReference['ReferencedContainer'].gsub(/^container:/,'')
       target_name   = buildableReference['BlueprintName']
-      project_path  = File.join @root, project_name  
-      project       = Xcode.project project_path 
+      project_path  = File.join @root, project_name
+      project       = Xcode.project project_path
       project.target(target_name)
     end
-    
+
     def parse_build_actions(doc)
       # Build Config
       @build_targets = []
-      
+
       @build_config = doc.xpath("//LaunchAction").first['buildConfiguration']
-      
+
       build_action_entries = doc.xpath("//BuildAction//BuildableReference").each do |ref|
-        @build_targets << target_from_build_reference(ref) 
+        @build_targets << target_from_build_reference(ref)
       end
     end
 

--- a/lib/xcode/version.rb
+++ b/lib/xcode/version.rb
@@ -1,3 +1,3 @@
 module Xcode
-  VERSION = "0.1.15.paperless"
+  VERSION = "0.1.15"
 end

--- a/lib/xcode/version.rb
+++ b/lib/xcode/version.rb
@@ -1,3 +1,3 @@
 module Xcode
-  VERSION = "0.1.15"
+  VERSION = "0.1.15.paperlesspost"
 end

--- a/lib/xcode/version.rb
+++ b/lib/xcode/version.rb
@@ -1,3 +1,3 @@
 module Xcode
-  VERSION = "0.1.15.paperlesspost"
+  VERSION = "0.1.15.paperless"
 end

--- a/lib/xcoder.rb
+++ b/lib/xcoder.rb
@@ -8,83 +8,84 @@ require 'plist'
 require 'xcode/keychain'
 require 'xcode/workspace'
 require 'xcode/buildfile'
+require 'multi_json'
 
 module Xcode
-  
+
   @@projects = nil
   @@workspaces = nil
   @@sdks = nil
-  
+
   #
   # Find all the projects within the current working directory.
-  # 
+  #
   # @return [Array<Project>] an array of the all the Projects found.
-  # 
+  #
   def self.projects
     @@projects = parse_projects if @@projects.nil?
-    @@projects  
+    @@projects
   end
-  
+
   #
   # Find all the workspaces within the current working directory.
-  # 
+  #
   # @return [Array<Workspaces>] an array of all the Workspaces found.
-  # 
+  #
   def self.workspaces
     @@workspaces = parse_workspaces if @@workspaces.nil?
     @@workspaces
   end
-  
+
   #
   # Find the project with the specified name within the current working directory.
-  # 
+  #
   # @note this method will raise an error when it is unable to find the project
   #   specified.
-  # 
+  #
   # @param [String] name of the project (e.g. NAME.xcodeproj) that is attempting
   #   to be found.
-  # 
+  #
   # @return [Project] the project found; an error is raise if a project is unable
   #   to be found.
-  # 
+  #
   def self.project(name)
     name = name.to_s
-    
+
     return Xcode::Project.new(name) if name=~/\.xcodeproj/
-    
+
     self.projects.each do |p|
       return p if p.name == name
     end
     raise "Unable to find a project named #{name}.  However, I did find these projects: #{self.projects.map {|p| p.name}.join(', ') }"
   end
-  
+
   #
   # Find the workspace with the specified name within the current working directory.
-  # 
+  #
   # @note this method will raise an error when it is unable to find the workspace
   #   specified.
-  # 
+  #
   # @param [String] name of the workspace (e.g. NAME.xcworkspace) that is attempting
   #   to be found.
-  # 
+  #
   # @return [Project] the workspace found; an error is raise if a workspace is unable
   #   to be found.
-  # 
+  #
   def self.workspace(name)
     name = name.to_s
-    
+
     return Xcode::Workspace.new(name) if name=~/\.xcworkspace/
-    
+
     self.workspaces.each do |p|
       return p if p.name == name
     end
     raise "Unable to find a workspace named #{name}.  However, I did find these workspaces: #{self.workspaces.map {|p| p.name}.join(', ') }"
   end
-  
+
   #
   # @param [String] dir the path to search for projects; defaults to using
   #   the current working directory.
-  # 
+  #
   # @return [Array<Project>] the projects found at the specified directory.
   #
   def self.find_projects(dir='.')
@@ -99,17 +100,17 @@ module Xcode
     parse_sdks if @@sdks.nil?
     @@sdks.values.include? sdk
   end
-  
+
   #
   # Available SDKs available on this particular system.
-  # 
+  #
   # @return [Array<String>] the available SDKs on the current system.
-  # 
+  #
   def self.available_sdks
     parse_sdks if @@sdks.nil?
     @@sdks
   end
- 
+
   private
   def self.parse_sdks
     @@sdks = {}
@@ -126,7 +127,7 @@ module Xcode
       end
     end
   end
-  
+
   def self.parse_workspaces(dir='.')
     projects = []
     Find.find(dir) do |path|

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
-describe Xcode::Builder do 
-  
+describe Xcode::Builder do
+
   context "when using a builder built from a configuration" do
 
     let(:configuration) { Xcode.project('TestProject').target('TestProject').config('Debug') }
@@ -9,26 +9,26 @@ describe Xcode::Builder do
     let(:subject) { configuration.builder }
 
     describe "#build" do
-      
-      let(:default_build_parameters) do        
+
+      let(:default_build_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{configuration.target.project.path}\""
-        cmd << "-target \"#{configuration.target.name}\"" 
+        cmd << "-target \"#{configuration.target.name}\""
         cmd << "-config \"#{configuration.name}\""
         cmd << "-sdk #{configuration.target.project.sdk}"
-        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
         cmd
       end
-      
+
       let(:macosx_build_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{configuration.target.project.path}\""
-        cmd << "-target \"#{configuration.target.name}\"" 
+        cmd << "-target \"#{configuration.target.name}\""
         cmd << "-config \"#{configuration.name}\""
         cmd << "-sdk macosx10.7"
-        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
         cmd
       end
 
@@ -36,17 +36,17 @@ describe Xcode::Builder do
         Xcode::Shell.should_receive(:execute).with(default_build_parameters,true)
         subject.build
       end
-      
+
       it "should allow the override of the sdk" do
         Xcode::Shell.should_receive(:execute).with(macosx_build_parameters, true)
         subject.build :sdk => 'macosx10.7'
       end
-      
+
     end
-    
+
     describe "#testflight" do
-      
-      # let(:testflight_parameters) do 
+
+      # let(:testflight_parameters) do
       #   ['curl',
       #   "--proxy http://proxyhost:8080",
       #   "-X POST http://testflightapp.com/api/builds.json",
@@ -58,10 +58,10 @@ describe Xcode::Builder do
       #   "-F notify=True",
       #   "-F distribution_lists='List1,List2'"]
       # end
-    
-      it "should upload ipa and dsym to testflight" do 
+
+      it "should upload ipa and dsym to testflight" do
         subject.build.package
-        
+
         result = subject.testflight("api_token", "team_token") do |tf|
           tf.should_receive(:upload).with(subject.ipa_path, subject.dsym_zip_path).and_return('result')
           tf.proxy = "http://proxyhost:8080"
@@ -69,42 +69,42 @@ describe Xcode::Builder do
           tf.lists << "List1"
           tf.lists << "List2"
         end
-      
+
         result.should == 'result'
       end
     end
-    
+
     describe "#test" do
-      
+
       let(:configuration) do
         Xcode.project('TestProject').target('LogicTests').config('Debug')
       end
-      
+
       let(:iphonesimulator_test_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{configuration.target.project.path}\""
-        cmd << "-target \"#{configuration.target.name}\"" 
+        cmd << "-target \"#{configuration.target.name}\""
         cmd << "-config \"#{configuration.name}\""
         cmd << "-sdk iphonesimulator"
-        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
         cmd.env["TEST_AFTER_BUILD"]="YES"
         cmd
       end
-      
+
       let(:macosx_test_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{configuration.target.project.path}\""
-        cmd << "-target \"#{configuration.target.name}\"" 
+        cmd << "-target \"#{configuration.target.name}\""
         cmd << "-config \"#{configuration.name}\""
         cmd << "-sdk macosx10.7"
-        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
         cmd.env["TEST_AFTER_BUILD"]="YES"
         cmd
       end
-      
-      
+
+
       it "should be able to run the test target on iphonesimulator" do
         Xcode::Shell.should_receive(:execute).with(iphonesimulator_test_parameters, false)
         subject.test :sdk => 'iphonesimulator'
@@ -114,7 +114,7 @@ describe Xcode::Builder do
         Xcode::Shell.should_receive(:execute).with(macosx_test_parameters, false)
         subject.test :sdk => 'macosx10.7'
       end
-      
+
       it "should not exit when test failed" do
         Xcode::Shell.stub(:execute)
         fake_parser = stub(:parser)
@@ -123,7 +123,7 @@ describe Xcode::Builder do
         Xcode::Test::Parsers::OCUnitParser.stub(:new => fake_parser)
         subject.test
       end
-      
+
     end
 
     describe "#clean" do
@@ -131,12 +131,12 @@ describe Xcode::Builder do
       let(:default_clean_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{configuration.target.project.path}\""
-        cmd << "-target \"#{configuration.target.name}\"" 
+        cmd << "-target \"#{configuration.target.name}\""
         cmd << "-config \"#{configuration.name}\""
         cmd << "-sdk iphoneos"
         cmd << "clean"
-        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(configuration.target.project.path)}/build/\""
         cmd
       end
 
@@ -149,22 +149,22 @@ describe Xcode::Builder do
     end
 
   end
-  
+
   context "when using a builder built from a scheme" do
 
     let(:scheme) { Xcode.project('TestProject').scheme('TestProject') }
-    
+
     let(:subject) { scheme.builder }
 
     describe "#build" do
-      
+
       let(:default_build_parameters) do
         cmd = Xcode::Shell::Command.new "xcodebuild"
         cmd << "-project \"#{scheme.build_targets.last.project.path}\""
         cmd << "-scheme \"#{scheme.name}\""
         cmd << "-sdk iphoneos"
-        cmd.env["OBJROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\"" 
-        cmd.env["SYMROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\""
+        cmd.env["SYMROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\""
         cmd
       end
 
@@ -172,9 +172,9 @@ describe Xcode::Builder do
         Xcode::Shell.should_receive(:execute).with(default_build_parameters, true)
         subject.build
       end
-      
+
     end
-    
+
     describe "#clean" do
 
       let(:default_clean_parameters) do
@@ -183,7 +183,7 @@ describe Xcode::Builder do
         cmd << "-scheme \"#{scheme.name}\""
         cmd << "-sdk iphoneos"
         cmd << "clean"
-        cmd.env["OBJROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\"" 
+        cmd.env["OBJROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\""
         cmd.env["SYMROOT"]="\"#{File.dirname(scheme.build_targets.last.project.path)}/build/\""
         cmd
       end
@@ -197,5 +197,5 @@ describe Xcode::Builder do
     end
 
   end
-  
+
 end

--- a/xcoder.gemspec
+++ b/xcoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_runtime_dependency "json"
+  s.add_runtime_dependency "multi_json"
   s.add_runtime_dependency "plist"  
   s.add_runtime_dependency "nokogiri"
   s.add_runtime_dependency "builder"


### PR DESCRIPTION
This branch does a couple things that we needed/wanted to build our workspace based project with xcoder:

1) Using MutliJson instead of JSON - we try not to use the JSON gem because of version inconsistencies and have switched as many gems as we can to using MultiJson which lets the end user pick their backend. This was a simple change.
2) Allowing setting of the configuration on a workspace based build. This is a passable option to `xcodebuild` and we need it to set the configuration to Ad_Hoc even though thats not the default for the scheme.
3) Allowing you to turn off and filter output with a block in every builder command. This was just passing through the `show_output` and `&block` vars for the specific commands. In our project we have show_output = false and then use this lambda as the "filter":

``` ruby
          clean_output = lambda {|out|
            if out !~ /^\s+/
              out = out.strip
              if out =~ /warning/i
                say out, :yellow
              elsif out =~ /(\=\=|EXECUTE)/
                say out, :cyan
              elsif out =~ /^error/i
                say out, :red
              elsif out =~ /\*\*/
                say out, :green
              else
                say out
              end
            end
          }
```

It may not look pretty but it makes the output from xcodebuild and package a lot easier to parse.

Thanks for the great and very useful project! 
