### PR TITLE
Fixing incorrect config object being passed to initializer

### DIFF
--- a/lib/xcode/builder/scheme_builder.rb
+++ b/lib/xcode/builder/scheme_builder.rb
@@ -16,8 +16,9 @@ module Xcode
     class SchemeBuilder < BaseBuilder
   
       def initialize(scheme)
-        @scheme     = scheme        
-        super @scheme.build_targets.last, @scheme.build_config
+        @scheme     = scheme
+        target = @scheme.build_targets.last
+        super target, target.config(@scheme.build_config)
       end
         
       def xcodebuild


### PR DESCRIPTION
Calling 

```
super @scheme.build_targets.last, @scheme.build_config
```

was leading to crashes later on when calling "package", for instance, since @scheme.build_config is a _String_, not a `Resource` object. 
