### PR TITLE
Add KIF Output Parser

### DIFF
--- a/lib/xcode/builder.rb
+++ b/lib/xcode/builder.rb
@@ -1,6 +1,7 @@
 require 'xcode/shell'
 require 'xcode/provisioning_profile'
 require 'xcode/test/parsers/ocunit_parser.rb'
+require 'xcode/test/parsers/kif_parser.rb'
 require 'xcode/builder/base_builder.rb'
 require 'xcode/builder/project_target_config_builder.rb'
 require 'xcode/builder/scheme_builder.rb'

--- a/lib/xcode/shell.rb
+++ b/lib/xcode/shell.rb
@@ -1,4 +1,5 @@
 require 'xcode/shell/command.rb'
+require 'pty'
 
 module Xcode
   module Shell
@@ -9,14 +10,15 @@ module Xcode
       out = []
       cmd = cmd.to_s
       
-      puts "EXECUTE: #{cmd}" if show_command
-      IO.popen (cmd) do |f| 
-        f.each do |line|
+      PTY.spawn(cmd) do |r, w, pid|
+        r.sync
+        r.each_line do |line|
           puts line if show_output
           yield(line) if block_given?
           out << line
         end 
       end
+      
       raise ExecutionError.new("Error (#{$?.exitstatus}) executing '#{cmd}'\n\n  #{out.join("  ")}") if $?.exitstatus>0
       out
     end

--- a/lib/xcode/test/formatters/junit_formatter.rb
+++ b/lib/xcode/test/formatters/junit_formatter.rb
@@ -42,7 +42,8 @@ module Xcode
             end
           end
           
-          File.open("#{@dir}/TEST-#{report.name}.xml", 'w') do |current_file|
+          filename = report.name.gsub(' ', '_')
+          File.open("#{@dir}/TEST-#{filename}.xml", 'w') do |current_file|
             current_file.write xml.target!
           end
           

--- a/lib/xcode/test/formatters/junit_formatter.rb
+++ b/lib/xcode/test/formatters/junit_formatter.rb
@@ -6,7 +6,7 @@ module Xcode
     module Formatters
       class JunitFormatter
         def initialize(dir)
-          @dir = File.expand_path(dir)
+          @dir = File.expand_path(dir).to_s
           FileUtils.mkdir_p(@dir)
         end
         
@@ -42,12 +42,16 @@ module Xcode
             end
           end
           
-          filename = report.name.gsub(' ', '_')
-          File.open("#{@dir}/TEST-#{filename}.xml", 'w') do |current_file|
+          File.open(File.join(@dir, sanitize_filename("TEST-#{report.name}.xml")), 'w') do |current_file|
             current_file.write xml.target!
           end
           
         end # write
+        
+        private
+        def sanitize_filename(filename)
+           filename.gsub(/[^0-9A-Za-z.\-]/, '_')
+        end
         
       end # JUnitFormatter
       

--- a/lib/xcode/test/formatters/stdout_formatter.rb
+++ b/lib/xcode/test/formatters/stdout_formatter.rb
@@ -46,8 +46,8 @@ module Xcode
         
         def after_suite(suite)
           color = (suite.total_passed_tests == suite.tests.count) ? :info : :error
-          print_task :test, "#{suite.total_passed_tests}/#{suite.tests.count}", color
-          # puts " [#{suite.total_passed_tests}/#{suite.tests.count}]", color
+          #print_task :test, "#{suite.total_passed_tests}/#{suite.tests.count}", color
+          puts " [#{suite.total_passed_tests}/#{suite.tests.count}]", color
         end
         
         def before_test(test)

--- a/lib/xcode/test/formatters/stdout_formatter.rb
+++ b/lib/xcode/test/formatters/stdout_formatter.rb
@@ -37,7 +37,8 @@ module Xcode
             end
           end
           
-          print_task :test, "End tests (#{report.failed? ? 'FAILED' : 'PASSED'}).  Ran #{@test_count} tests in #{report.duration}s", report.failed? ? :error : :info
+          print_task :test, "Finished in #{report.duration} seconds", :info
+          print_task :test, "#{@test_count} tests, #{@errors.count} failures", report.failed? ? :error : :info
         end
         
         def before_suite(suite)

--- a/lib/xcode/test/parsers/kif_parser.rb
+++ b/lib/xcode/test/parsers/kif_parser.rb
@@ -1,0 +1,87 @@
+require 'xcode/test/report'
+require 'time'
+
+module Xcode
+  module Test    
+    module Parsers
+      
+      class KIFParser
+        attr_accessor :report, :builder
+        
+        def initialize(report = Xcode::Test::Report.new)
+          @report = report
+          @awaiting_scenario_name = false
+          yield self if block_given?
+        end
+    
+        def flush
+          @report.finish
+        end
+    
+        def <<(piped_row)
+          if @awaiting_scenario_name
+            if match = piped_row.match(/\[\d+\:.+\]\s(.+)/)
+              name = match[1].strip
+              @report.add_suite name, Time.now            
+              @awaiting_scenario_name = false
+            end
+            return
+          end
+          
+          case piped_row.force_encoding("UTF-8")
+            
+            when /BEGIN KIF TEST RUN: (\d+) scenarios/
+              @report.start
+            
+            when /BEGIN SCENARIO (\d+)\/(\d+) \(\d+ steps\)/
+              @awaiting_scenario_name = true
+              
+            when /END OF SCENARIO \(duration (\d+\.\d+)s/
+              @report.in_current_suite do |suite|
+                suite.finish(Time.now)
+              end
+              
+            when /(PASS|FAIL) \((\d+\.\d+s)\): (.+)/
+              duration = $2.to_f
+              name = $3.strip
+              @report.in_current_suite do |suite|
+                test = suite.add_test_case(name)
+                
+                if $1 == 'PASS'
+                  test.passed(duration)
+                else
+                  test.failed(duration)
+                end
+              end
+              
+            when /KIF TEST RUN FINISHED: \d+ failures \(duration (\d+\.\d+)s\)/
+              @report.finish
+
+            when /(.*): error: -\[(\S+) (\S+)\] : (.*)/
+              message = $4
+              location = $1
+              @report.in_current_test do |test|
+                test.add_error(message, location)
+              end
+            
+            # when /failed with exit code (\d+)/, 
+            when /BUILD FAILED/
+              @report.finish
+            
+            when /Segmentation fault/
+              @report.abort
+            
+            when /the iPhoneSimulator platform does not currently support application-hosted tests/
+              raise "Application tests are not currently supported by the iphone simulator.  If these are logic tests, try unsetting TEST_HOST in your project config"
+            else
+              @report.in_current_test do |test|
+                test << piped_row
+              end
+          end # case
+        
+        end # <<
+      
+      end # OCUnitParser
+    end # Parsers
+  end # Test
+end # Xcode


### PR DESCRIPTION
This pull request adds an output parser for the KIF integration testing framework from Square (see https://github.com/square/KIF). There are a few minor changes under the hood that were necessary to enable the parser:
- Switched the implementation from open3 to PTY to capture output flushed to stderr as well as stdout
- Replace all spaces with underscores in test names in the JUnit formatter. KIF scenarios are typically written as complete sentences.

For reference, I am running this via `ios-sim` with a Rake task:

``` ruby
desc 'Run the GateGuru KIF integration tests suite'
task :integration do
  scheme = Xcode.workspace(:GateGuru).scheme('Integration Tests')

  # Execute the build quietly
  cmd = scheme.builder.xcodebuild
  cmd << "-sdk iphonesimulator"

  output = []
  begin
    puts "Building target..."
    Xcode::Shell.execute(cmd, false) do |line|
      raise line if line =~ /BUILD FAILED/
      output << line
    end
  rescue => e
    puts output.join("\n")
    raise e
  end

  # Run the Integration Tests
  report = Xcode::Test::Report.new
  cmd = Xcode::Shell::Command.new(%q{ios-sim launch "build/Products/Test-iphonesimulator/GateGuru (Integration Tests).app" --retina})

  report.add_formatter :stdout, { :color_output => true }
  report.add_formatter :junit, 'test-reports'

  parser = Xcode::Test::Parsers::KIFParser.new(report)

  begin
    puts "Executing suite via command #{cmd}"
    cmd.execute(false) do |line|
      parser << line
    end
  rescue Xcode::Shell::ExecutionError => e
    # FIXME: Perhaps we should always raise this?
    raise e if report.suites.count==0
  ensure
    parser.flush
  end
end
```
