### PR TITLE
Do not try to install an already installed provisioning profile

### DIFF
--- a/lib/xcode/builder/base_builder.rb
+++ b/lib/xcode/builder/base_builder.rb
@@ -324,6 +324,13 @@ module Xcode
       def install_profile
         return nil if @profile.nil?
 
+        # if we got an already installed profile just skip
+        Xcode::ProvisioningProfile.installed_profiles.each { |profile|
+          if profile.path.include? @profile
+            return profile
+          end
+        }
+
         # TODO: remove other profiles for the same app?
         p = ProvisioningProfile.new(@profile)
         p.install


### PR DESCRIPTION
This results in a race condition because the already installed profile
is deleted before reinstalling it, so it deletes the file it wants to
install
