### PR TITLE
Do not reinstall if profile is same and is already installed

### DIFF
--- a/lib/xcode/builder/base_builder.rb
+++ b/lib/xcode/builder/base_builder.rb
@@ -17,10 +17,6 @@ module Xcode
         @config = config
 
         @sdk = @target.project.sdk
-        @build_path = File.join File.dirname(@target.project.path), "Build"
-        FileUtils.mkdir_p @build_path
-        @objroot = @build_path
-        @symroot = File.join(@build_path, 'Products')
       end
 
       def cocoapods_installed?
@@ -51,7 +47,7 @@ module Xcode
       end
 
       def xcodebuild_parser
-        filename = File.join(@build_path, "xcodebuild-output.txt")
+        filename = File.join(build_path, "xcodebuild-output.txt")
         parser = Xcode::Builder::XcodebuildParser.new filename
         parser
       end
@@ -59,8 +55,8 @@ module Xcode
       def prepare_xcodebuild sdk=@sdk #:yield: Xcode::Shell::Command
         cmd = Xcode::Shell::Command.new 'xcodebuild'
 
-        cmd.env["OBJROOT"]  = "\"#{@objroot}/\""
-        cmd.env["SYMROOT"]  = "\"#{@symroot}/\""
+        cmd.env["OBJROOT"]  = "\"#{objroot}/\""
+        cmd.env["SYMROOT"]  = "\"#{symroot}/\""
 
         profile = install_profile
         unless profile.nil?
@@ -266,7 +262,7 @@ module Xcode
       end
 
       def configuration_build_path
-        "#{@symroot}/#{@config.name}-#{@sdk}"
+        "#{symroot}/#{@config.name}-#{@sdk}"
       end
 
       def entitlements_path
@@ -309,6 +305,25 @@ module Xcode
 
       def bundle_version
         @config.info_plist.version
+      end
+
+      def objroot
+        @objroot ||= build_path
+      end
+
+      def symroot
+        @symroot ||= File.join(build_path, 'Products')
+      end
+
+      def build_path=(path)
+        @build_path ||= path
+        FileUtils.mkdir_p @build_path
+      end
+
+      def build_path
+        return @build_path if @build_path
+        @build_path = File.join File.dirname(@target.project.path), "Build"
+        FileUtils.mkdir_p @build_path
       end
 
       private

--- a/lib/xcode/builder/build_parser.rb
+++ b/lib/xcode/builder/build_parser.rb
@@ -62,10 +62,12 @@ module Xcode
             # Empty line, ignore
           elsif piped_row=~/[A-Z]+\s\=\s/
             # some build env info
-          elsif piped_row=~/^warning:/
-            log_xcode "#{piped_row.gsub(/^warning:\s/,'')}", :warning
+          elsif piped_row=~/^warning:/i
+            log_xcode "#{piped_row.gsub(/^warning:\s/i,'')}", :warning
             # print "\n warning: ", :yellow
-            # print "#{piped_row.gsub(/^warning:\s/,'')}"            
+            # print "#{piped_row.gsub(/^warning:\s/,'')}" 
+          elsif piped_row=~/^ld: warning:/i
+            log_xcode "#{piped_row.gsub(/^ld: warning:\s/i,'')}", :warning       
           elsif piped_row=~/Unable to validate your application/
             log_xcode piped_row, :warning
             # print "\n warning: ", :yellow

--- a/lib/xcode/provisioning_profile.rb
+++ b/lib/xcode/provisioning_profile.rb
@@ -82,7 +82,8 @@ module Xcode
 
     def self.find_installed_by_uuid uuid
       ProvisioningProfile.installed_profiles.each do |p|
-      return p if p.uuid == uuid
+        return p if p.uuid == uuid
+      end
     end
     
   end

--- a/lib/xcode/provisioning_profile.rb
+++ b/lib/xcode/provisioning_profile.rb
@@ -57,6 +57,10 @@ module Xcode
     def install 
       ProvisioningProfile.installed_profiles.each do |installed|
         if installed.identifiers==self.identifiers and installed.uuid==self.uuid
+
+          # Do not reinstall if profile is same and is already installed
+          return if (self.path == self.install_path.gsub(/\\ /, ' '))
+
           installed.uninstall
         end
       end
@@ -74,6 +78,11 @@ module Xcode
       Dir["#{self.profiles_path}/*.mobileprovision"].map do |file|
         ProvisioningProfile.new(file)
       end
+    end
+
+    def self.find_installed_by_uuid uuid
+      ProvisioningProfile.installed_profiles.each do |p|
+      return p if p.uuid == uuid
     end
     
   end


### PR DESCRIPTION
Sometimes I have a profile installed and I don't want to re-install it all the time.
Example when using like this

``` ruby
# Buildspec
pprofile_id = '840823DD-B3CC-456A-8F1A-XXX'
pprofile = Xcode::ProvisioningProfile.find_installed_by_uuid(pprofile_id)
puts "Using PProfile: #{pprofile.name} in #{pprofile.path}"
pprofile_path = pprofile.path

group :build do
  use :MyProject, :scheme => :MyScheme
  profile pprofile_path
end
```
