### PR TITLE
Only consider FileRef's in the workspace XML that have a location that ends in .xcodeproj as Projects.

### DIFF
--- a/lib/xcode/workspace.rb
+++ b/lib/xcode/workspace.rb
@@ -15,7 +15,7 @@ module Xcode
       doc = Nokogiri::XML(open("#{@path}/contents.xcworkspacedata"))
       doc.search("FileRef").each do |file|
         location = file["location"]
-        if matcher = location.match(/^group:(.+)$/)
+        if (matcher = location.match(/^group:(.+\.xcodeproj)$/i))
           project_path = "#{workspace_root}/#{matcher[1]}"
           begin
             @projects << Xcode::Project.new(project_path)


### PR DESCRIPTION
Only consider FileRef's in the workspace XML that have a location that ends in .xcodeproj as Projects.
