### PR TITLE
Use standard SDK for testing and allow overriding

### DIFF
--- a/lib/xcode/builder/base_builder.rb
+++ b/lib/xcode/builder/base_builder.rb
@@ -139,9 +139,9 @@ module Xcode
       #
       # Build the project
       #
-      def build options = {}, &block
+      def build options = {:sdk => @sdk}, &block
         print_task :builder, "Building #{product_name}", :notice
-        cmd = prepare_build_command options[:sdk]||@sdk
+        cmd = prepare_build_command options[:sdk]
 
         with_keychain do
           cmd.execute
@@ -156,11 +156,11 @@ module Xcode
       # If a block is provided, the report is yielded for configuration before the test is run
       #
       # TODO: Move implementation to the Xcode::Test module
-      def test options = {:sdk => 'iphonesimulator', :show_output => false}
+      def test options = {:sdk => @sdk, :show_output => false}
         report = Xcode::Test::Report.new
         print_task :builder, "Testing #{product_name}", :notice
 
-        cmd = prepare_test_command options[:sdk]||@sdk
+        cmd = prepare_test_command options[:sdk]
 
         if block_given?
           yield(report)

--- a/lib/xcode/builder/scheme_builder.rb
+++ b/lib/xcode/builder/scheme_builder.rb
@@ -36,11 +36,11 @@ module Xcode
       #   cmd
       # end
       
-      def test
+      def test options = {:sdk => @sdk, :show_output => false}
         unless @scheme.testable?
           print_task :builder, "Nothing to test", :warning        
         else
-          super
+          super options
         end
       end
 

--- a/lib/xcode/builder/scheme_builder.rb
+++ b/lib/xcode/builder/scheme_builder.rb
@@ -21,7 +21,7 @@ module Xcode
         super @target, @target.config(@scheme.archive_config)
       end
 
-      def prepare_xcodebuild sdk=nil
+      def prepare_xcodebuild sdk=@sdk
         cmd = super sdk
         cmd << @scheme.parent.to_xcodebuild_option
         cmd << "-scheme \"#{@scheme.name}\""


### PR DESCRIPTION
The base test method uses `iphonesimulator` as the default SDK. This should be `@sdk` like all other methods.

The scheme test method does not have an options parameter. So it is not possible to override the default SDK when using a scheme.

This fixes both issues.
