### PR TITLE
Initialize sdk with nil, use only when overriding the sdk to use

### DIFF
--- a/lib/xcode/project.rb
+++ b/lib/xcode/project.rb
@@ -53,7 +53,7 @@ module Xcode
     #   `iphoneos`.
     #
     def initialize(path, sdk=nil)
-      @sdk = sdk || "iphoneos"  # FIXME: should support OSX/simulator too
+      @sdk = sdk
       @path = File.expand_path path
       @schemes = nil
       @groups = []


### PR DESCRIPTION
It is unnecessary to initialize the project sdk value with 'iphoneos'. xcodebuild does this automatically for the targets. You only want to be able to set the SDK value to override the settings.

Initializing the sdk with nil achieves this.
