### PR TITLE
Call colorize only if necessary

### DIFF
--- a/lib/xcode/terminal_output.rb
+++ b/lib/xcode/terminal_output.rb
@@ -91,13 +91,19 @@ module Xcode
     end
 
     def puts(text, color = :default)
-      color_params = color_output? ? color : {}
-      super(text.colorize(color_params))
+      if not(color_output?) || color == :default
+        super(text)
+      else
+        super(text.colorize(color))
+      end
     end
 
     def print(text, color = :default)
-      color_params = color_output? ? color : {}
-      super(text.colorize(color_params))
+      if not(color_output?) || color == :default
+        super(text)
+      else
+        super(text.colorize(color))
+      end
     end
 
     def self.terminal_supports_colors?


### PR DESCRIPTION
xcodebuild uses ANSI escapes for color output as well. If you pass them to colorize they will be escaped resulting in e.g. [1m in your build output:

```
 : [1mClean.Remove[0m clean [1m/Users/ArloLOK/Developer/ServiceDiscovery/Build/Products/Release/libPods-osx-CocoaLumberjack.a[0m
```
