### PR TITLE
Change S3 to use HTTPS

### DIFF
--- a/lib/xcode/deploy/s3.rb
+++ b/lib/xcode/deploy/s3.rb
@@ -25,7 +25,7 @@ module Xcode
 
   		def deploy
   			remote_ipa = upload @builder.ipa_path
-  			base_url = remote_ipa.public_url(:secure => false).to_s.split("/")[0..-2].join("/")
+  			base_url = remote_ipa.public_url(:secure => true).to_s.split("/")[0..-2].join("/")
 
   			WebAssets.generate @builder, base_url do |dir|
   				Dir["#{dir}/*"].each do |path|


### PR DESCRIPTION
iOS 7.1 requires OTA app installation links to use HTTPS – they fail otherwise.
